### PR TITLE
Optimize matrix world inverse caching

### DIFF
--- a/lib/three-vrm.module.js
+++ b/lib/three-vrm.module.js
@@ -2785,17 +2785,30 @@ class VRMSpringBone {
         this._prevTail.applyMatrix4(_matA);
         this._nextTail.applyMatrix4(_matA);
         // uninstall inverse cache
-        if ((_a = this._center) === null || _a === void 0 ? void 0 : _a.userData.inverseCacheProxy) {
+        /* if ((_a = this._center) === null || _a === void 0 ? void 0 : _a.userData.inverseCacheProxy) {
             this._center.userData.inverseCacheProxy.revert();
             delete this._center.userData.inverseCacheProxy;
-        }
+        } */
         // change the center
         this._center = center;
         // install inverse cache
         if (this._center) {
-            if (!this._center.userData.inverseCacheProxy) {
+            const matrixWorldInverse = new THREE.Matrix4();
+            let matrixWorldInverseNeedsUpdate = true;
+            this._center.updateMatrixWorld = (_updateMatrixWorld => function() {
+                matrixWorldInverseNeedsUpdate = true;
+                return _updateMatrixWorld.apply(this, arguments);
+            })(this._center.updateMatrixWorld);
+            this._center.getMatrixWorldInverse = () => {
+              if (matrixWorldInverseNeedsUpdate) {
+                matrixWorldInverse.copy(this._center.matrixWorld).invert();
+                matrixWorldInverseNeedsUpdate = false;
+              }
+              return matrixWorldInverse;
+            };
+            /* if (!this._center.userData.inverseCacheProxy) {
                 this._center.userData.inverseCacheProxy = new Matrix4InverseCache(this._center.matrixWorld);
-            }
+            } */
         }
         // convert tails to center space
         this._getMatrixWorldToCenter(_matA);
@@ -2936,7 +2949,8 @@ class VRMSpringBone {
      */
     _getMatrixWorldToCenter(target) {
         if (this._center) {
-            target.copy(this._center.userData.inverseCacheProxy.inverse);
+            // target.copy(this._center.userData.inverseCacheProxy.inverse);
+            target.copy(this._center.getMatrixWorldInverse());
         }
         else {
             target.identity();


### PR DESCRIPTION
This removes the per-matrix element hack `three-vrm` had, which was intercepting every matrix world update on some bones 16 times.