### PR TITLE
Synchronous bone import

### DIFF
--- a/lib/three-vrm.module.js
+++ b/lib/three-vrm.module.js
@@ -3029,77 +3029,90 @@ class VRMSpringBoneImporter {
      */
     import(gltf) {
         var _a;
-        return __awaiter(this, void 0, void 0, function* () {
-            const vrmExt = (_a = gltf.parser.json.extensions) === null || _a === void 0 ? void 0 : _a.VRM;
-            if (!vrmExt)
-                return null;
-            const schemaSecondaryAnimation = vrmExt.secondaryAnimation;
-            if (!schemaSecondaryAnimation)
-                return null;
-            // 衝突判定球体メッシュ。
-            const colliderGroups = yield this._importColliderMeshGroups(gltf, schemaSecondaryAnimation);
-            // 同じ属性（stiffinessやdragForceが同じ）のボーンはboneGroupにまとめられている。
-            // 一列だけではないことに注意。
-            const springBoneGroupList = yield this._importSpringBoneGroupList(gltf, schemaSecondaryAnimation, colliderGroups);
-            return new VRMSpringBoneManager(colliderGroups, springBoneGroupList);
-        });
+        const vrmExt = (_a = gltf.parser.json.extensions) === null || _a === void 0 ? void 0 : _a.VRM;
+        if (!vrmExt)
+            return null;
+        const schemaSecondaryAnimation = vrmExt.secondaryAnimation;
+        if (!schemaSecondaryAnimation)
+            return null;
+        // 衝突判定球体メッシュ。
+        const colliderGroups = this._importColliderMeshGroups(gltf, schemaSecondaryAnimation); // XXX
+        // 同じ属性（stiffinessやdragForceが同じ）のボーンはboneGroupにまとめられている。
+        // 一列だけではないことに注意。
+        const springBoneGroupList = this._importSpringBoneGroupList(gltf, schemaSecondaryAnimation, colliderGroups); // XXX
+        return new VRMSpringBoneManager(colliderGroups, springBoneGroupList);
     }
     _createSpringBone(bone, params = {}) {
         return new VRMSpringBone(bone, params);
     }
     _importSpringBoneGroupList(gltf, schemaSecondaryAnimation, colliderGroups) {
-        return __awaiter(this, void 0, void 0, function* () {
-            const springBoneGroups = schemaSecondaryAnimation.boneGroups || [];
-            const springBoneGroupList = [];
-            yield Promise.all(springBoneGroups.map((vrmBoneGroup) => __awaiter(this, void 0, void 0, function* () {
-                if (vrmBoneGroup.stiffiness === undefined ||
-                    vrmBoneGroup.gravityDir === undefined ||
-                    vrmBoneGroup.gravityDir.x === undefined ||
-                    vrmBoneGroup.gravityDir.y === undefined ||
-                    vrmBoneGroup.gravityDir.z === undefined ||
-                    vrmBoneGroup.gravityPower === undefined ||
-                    vrmBoneGroup.dragForce === undefined ||
-                    vrmBoneGroup.hitRadius === undefined ||
-                    vrmBoneGroup.colliderGroups === undefined ||
-                    vrmBoneGroup.bones === undefined ||
-                    vrmBoneGroup.center === undefined) {
+        const springBoneGroups = schemaSecondaryAnimation.boneGroups || [];
+        const springBoneGroupList = [];
+        springBoneGroups.forEach((vrmBoneGroup) => {
+            if (vrmBoneGroup.stiffiness === undefined ||
+                vrmBoneGroup.gravityDir === undefined ||
+                vrmBoneGroup.gravityDir.x === undefined ||
+                vrmBoneGroup.gravityDir.y === undefined ||
+                vrmBoneGroup.gravityDir.z === undefined ||
+                vrmBoneGroup.gravityPower === undefined ||
+                vrmBoneGroup.dragForce === undefined ||
+                vrmBoneGroup.hitRadius === undefined ||
+                vrmBoneGroup.colliderGroups === undefined ||
+                vrmBoneGroup.bones === undefined ||
+                vrmBoneGroup.center === undefined) {
+                return;
+            }
+            const stiffnessForce = vrmBoneGroup.stiffiness;
+            const gravityDir = new THREE.Vector3(vrmBoneGroup.gravityDir.x, vrmBoneGroup.gravityDir.y, -vrmBoneGroup.gravityDir.z);
+            const gravityPower = vrmBoneGroup.gravityPower;
+            const dragForce = vrmBoneGroup.dragForce;
+            const radius = vrmBoneGroup.hitRadius;
+            const colliders = [];
+            vrmBoneGroup.colliderGroups.forEach((colliderIndex) => {
+                colliders.push(...colliderGroups[colliderIndex].colliders);
+            });
+            const springBoneGroup = [];
+            vrmBoneGroup.bones.forEach((nodeIndex) => {
+                // VRMの情報から「揺れモノ」ボーンのルートが取れる
+                let skinnedMesh = null;
+                const _recurse = o => {
+                    if (o.isSkinnedMesh) {
+                        skinnedMesh = o;
+                    } else {
+                        for (const child of o.children) {
+                            _recurse(child);
+                        }
+                    }
+                };
+                _recurse(gltf.scene);
+                const springRootBone = skinnedMesh.skeleton.bones[nodeIndex - 1];
+                // const springRootBoneJson = gltf.parser.json.nodes[nodeIndex];
+                if (!springRootBone) { // XXX
+                    debugger;
+                }
+                // const springRootBone = yield gltf.parser.getDependency('node', nodeIndex);
+                const center = vrmBoneGroup.center !== -1 ? gltf.parser.json.nodes[vrmBoneGroup.center] : null;
+                // const center = vrmBoneGroup.center !== -1 ? yield gltf.parser.getDependency('node', vrmBoneGroup.center) : null;
+                // it's weird but there might be cases we can't find the root bone
+                if (!springRootBone) {
                     return;
                 }
-                const stiffnessForce = vrmBoneGroup.stiffiness;
-                const gravityDir = new THREE.Vector3(vrmBoneGroup.gravityDir.x, vrmBoneGroup.gravityDir.y, -vrmBoneGroup.gravityDir.z);
-                const gravityPower = vrmBoneGroup.gravityPower;
-                const dragForce = vrmBoneGroup.dragForce;
-                const radius = vrmBoneGroup.hitRadius;
-                const colliders = [];
-                vrmBoneGroup.colliderGroups.forEach((colliderIndex) => {
-                    colliders.push(...colliderGroups[colliderIndex].colliders);
-                });
-                const springBoneGroup = [];
-                yield Promise.all(vrmBoneGroup.bones.map((nodeIndex) => __awaiter(this, void 0, void 0, function* () {
-                    // VRMの情報から「揺れモノ」ボーンのルートが取れる
-                    const springRootBone = yield gltf.parser.getDependency('node', nodeIndex);
-                    const center = vrmBoneGroup.center !== -1 ? yield gltf.parser.getDependency('node', vrmBoneGroup.center) : null;
-                    // it's weird but there might be cases we can't find the root bone
-                    if (!springRootBone) {
-                        return;
-                    }
-                    springRootBone.traverse((bone) => {
-                        const springBone = this._createSpringBone(bone, {
-                            radius,
-                            stiffnessForce,
-                            gravityDir,
-                            gravityPower,
-                            dragForce,
-                            colliders,
-                            center,
-                        });
-                        springBoneGroup.push(springBone);
+                springRootBone.traverse((bone) => {
+                    const springBone = this._createSpringBone(bone, {
+                        radius,
+                        stiffnessForce,
+                        gravityDir,
+                        gravityPower,
+                        dragForce,
+                        colliders,
+                        center,
                     });
-                })));
-                springBoneGroupList.push(springBoneGroup);
-            })));
-            return springBoneGroupList;
+                    springBoneGroup.push(springBone);
+                });
+            });
+            springBoneGroupList.push(springBoneGroup);
         });
+        return springBoneGroupList;
     }
     /**
      * Create an array of [[VRMSpringBoneColliderGroup]].
@@ -3108,38 +3121,52 @@ class VRMSpringBoneImporter {
      * @param schemaSecondaryAnimation A `secondaryAnimation` field of VRM
      */
     _importColliderMeshGroups(gltf, schemaSecondaryAnimation) {
-        return __awaiter(this, void 0, void 0, function* () {
-            const vrmColliderGroups = schemaSecondaryAnimation.colliderGroups;
-            if (vrmColliderGroups === undefined)
-                return [];
-            const colliderGroups = [];
-            vrmColliderGroups.forEach((colliderGroup) => __awaiter(this, void 0, void 0, function* () {
-                if (colliderGroup.node === undefined || colliderGroup.colliders === undefined) {
+        const vrmColliderGroups = schemaSecondaryAnimation.colliderGroups;
+        if (vrmColliderGroups === undefined)
+            return [];
+        const colliderGroups = [];
+        vrmColliderGroups.forEach((colliderGroup) => {
+            if (colliderGroup.node === undefined || colliderGroup.colliders === undefined) {
+                return;
+            }
+            let skinnedMesh = null;
+            const _recurse = o => {
+              if (o.isSkinnedMesh) {
+                skinnedMesh = o;
+              } else {
+                for (const child of o.children) {
+                  _recurse(child);
+                }
+              }
+            };
+            _recurse(gltf.scene);
+            const bone = skinnedMesh.skeleton.bones[colliderGroup.node - 1];
+            // const boneJson = gltf.parser.json.nodes[colliderGroup.node];
+            if (!bone) { // XXX
+                debugger;
+            }
+            // const bone = gltf.parser.getDependency('node', colliderGroup.node);
+            const colliders = [];
+            colliderGroup.colliders.forEach((collider) => {
+                if (collider.offset === undefined ||
+                    collider.offset.x === undefined ||
+                    collider.offset.y === undefined ||
+                    collider.offset.z === undefined ||
+                    collider.radius === undefined) {
                     return;
                 }
-                const bone = yield gltf.parser.getDependency('node', colliderGroup.node);
-                const colliders = [];
-                colliderGroup.colliders.forEach((collider) => {
-                    if (collider.offset === undefined ||
-                        collider.offset.x === undefined ||
-                        collider.offset.y === undefined ||
-                        collider.offset.z === undefined ||
-                        collider.radius === undefined) {
-                        return;
-                    }
-                    const offset = _v3A$1.set(collider.offset.x, collider.offset.y, -collider.offset.z);
-                    const colliderMesh = this._createColliderMesh(collider.radius, offset);
-                    bone.add(colliderMesh);
-                    colliders.push(colliderMesh);
-                });
-                const colliderMeshGroup = {
-                    node: colliderGroup.node,
-                    colliders,
-                };
-                colliderGroups.push(colliderMeshGroup);
-            }));
-            return colliderGroups;
+                const offset = _v3A$1.set(collider.offset.x, collider.offset.y, -collider.offset.z);
+                const colliderMesh = this._createColliderMesh(collider.radius, offset);
+                bone.add(colliderMesh);
+                colliders.push(colliderMesh);
+            });
+            const colliderMeshGroup = {
+                node: colliderGroup.node,
+                colliders,
+            };
+            colliderGroups.push(colliderMeshGroup);
         });
+        return colliderGroups;
     }
     /**
      * Create a collider mesh.

--- a/lib/three-vrm.module.js
+++ b/lib/three-vrm.module.js
@@ -3086,10 +3086,6 @@ class VRMSpringBoneImporter {
                 };
                 _recurse(gltf.scene);
                 const springRootBone = skinnedMesh.skeleton.bones[nodeIndex - 1];
-                // const springRootBoneJson = gltf.parser.json.nodes[nodeIndex];
-                if (!springRootBone) { // XXX
-                    debugger;
-                }
                 // const springRootBone = yield gltf.parser.getDependency('node', nodeIndex);
                 const center = vrmBoneGroup.center !== -1 ? gltf.parser.json.nodes[vrmBoneGroup.center] : null;
                 // const center = vrmBoneGroup.center !== -1 ? yield gltf.parser.getDependency('node', vrmBoneGroup.center) : null;
@@ -3141,10 +3137,6 @@ class VRMSpringBoneImporter {
             };
             _recurse(gltf.scene);
             const bone = skinnedMesh.skeleton.bones[colliderGroup.node - 1];
-            // const boneJson = gltf.parser.json.nodes[colliderGroup.node];
-            if (!bone) { // XXX
-                debugger;
-            }
             // const bone = gltf.parser.getDependency('node', colliderGroup.node);
             const colliders = [];
             colliderGroup.colliders.forEach((collider) => {


### PR DESCRIPTION
Makes `VRMSpringBoneImporter.import` synchronous. It was previously `async`.

Callers are expected to have fully loaded the GLTF beforehand, where we source synchronous references from.